### PR TITLE
Add mapping to align multiline lists

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -85,6 +85,7 @@ let g:haskell_tabular = 1
 vmap a= :Tabularize /=<CR>
 vmap a; :Tabularize /::<CR>
 vmap a- :Tabularize /-><CR>
+vmap al :Tabularize /[\[|,]<CR>
 
 " == ctrl-p ==
 


### PR DESCRIPTION
This will help align multi-line lists like

```
[ "item the first"
      , "item the second"
  , "item the third" ]
```

to something more like

```
[ "item the first"
, "item the second"
, "item the third" ]
```

It's just a thought; I was inspired to put this in my own vimrc after I saw your post, and read up on vim-tabularize.
