### PR TITLE
Fix bug occuring with empty import lists.

### DIFF
--- a/vim/syntax/haskell.vim
+++ b/vim/syntax/haskell.vim
@@ -141,11 +141,11 @@ sy match hsImportParams "as\s\+\(\w\+\)" contained
 sy match hsImportParams "hiding" contained
     \ contains=hsHidingLabel
     \ nextgroup=hsImportParams,hsImportIllegal skipwhite 
-sy region hsImportParams start="(" end=")" contained
-    \ contains=hsBlockComment,hsLineComment, hsType,hsDelimTypeExport,hs_hlFunctionName,hs_OpFunctionName
+sy match hsImportParams "\(\w\*\)" contained
+    \ contains=hsBlockComment,hsLineComment,hsType,hsDelimTypeExport,hs_hlFunctionName,hs_OpFunctionName
     \ nextgroup=hsImportIllegal skipwhite
 
-" hi hsImport guibg=red
+"hi hsImport guibg=red
 "hi hsImportParams guibg=bg
 "hi hsImportIllegal guibg=bg
 "hi hsModuleName guibg=bg


### PR DESCRIPTION
When an import statement such as 'import Control.Monad ()' was
encountered, featuring an empty import list (what you would do
to only import instances), it messed up the syntax detection for
the remainder of the file. This patch fixes that issue.
