### PR TITLE
Fix bug occuring with empty export declaration.

### DIFF
--- a/vim/syntax/haskell.vim
+++ b/vim/syntax/haskell.vim
@@ -184,7 +184,7 @@ syn match hsModuleCommentA "--.*\n"
   \ contains=hsCommentTodo,@Spell contained
   \ nextgroup=hsModuleCommentA,hsModuleExports,hsModuleWhereLabel skipwhite skipnl
 
-syn region hsModuleExports start="(" end=")" contained
+syn match hsModuleExports "\(\w\*\)" contained
    \ nextgroup=hsModuleCommentB,hsModuleWhereLabel skipwhite skipnl
    \ contains=hsBlockComment,hsLineComment,hsType,hsDelimTypeExport,hs_hlFunctionName,hs_OpFunctionName,hsExportModule
 

--- a/vimrc
+++ b/vimrc
@@ -85,7 +85,8 @@ let g:haskell_tabular = 1
 vmap a= :Tabularize /=<CR>
 vmap a; :Tabularize /::<CR>
 vmap a- :Tabularize /-><CR>
-vmap al :Tabularize /[\[|,]<CR>
+vmap a, :Tabularize /<-<CR>
+vmap al :Tabularize /[\[\\|,]<CR>
 
 " == ctrl-p ==
 


### PR DESCRIPTION
This is the same syntax bug that occured with import lists (dd8144)
only it occurs after an empty export declaration such as
'module Foo () where', in a module where you're only exporting
instances.

I also did the following:
- Fix regex bug with the list alignment Tabular command. Vim
  considered it an error before the fix.
- Add Tabular command for '<-' binding in do notation.

If you don't like all the changes, feel free to pick and choose or let me know and I'll create a separate pull request for just one change :) I just felt it would be more convenient to PR all of them at once.
