### PR TITLE
Cabal syntax changes

### DIFF
--- a/vim/syntax/cabal.vim
+++ b/vim/syntax/cabal.vim
@@ -26,25 +26,26 @@ elseif exists("b:current_syntax")
   finish
 endif
 
-syn match	cabalCategory	"\c\<executable\>"
-syn match	cabalCategory	"\c\<library\>"
-syn match	cabalCategory	"\c\<foreign-library\>"
-syn match	cabalCategory	"\c\<benchmark\>"
-syn match	cabalCategory	"\c\<test-suite\>"
-syn match	cabalCategory	"\c\<source-repository\>"
-syn match	cabalCategory	"\c\<flag\>"
-syn match	cabalCategory	"\c\<custom-setup\>"
+syn match	cabalCategory	"^\c\<executable\>"
+syn match	cabalCategory	"^\c\<library\>"
+syn match	cabalCategory	"^\c\<foreign-library\>"
+syn match	cabalCategory	"^\c\<benchmark\>"
+syn match	cabalCategory	"^\c\<test-suite\>"
+syn match	cabalCategory	"^\c\<source-repository\>"
+syn match	cabalCategory	"^\c\<flag\>"
+syn match	cabalCategory	"^\c\<custom-setup\>"
 
-syn keyword     cabalConditional    if else
-syn match       cabalOperator       "&&\|||\|!\|==\|>=\|<=\|<\|>\|^>="
+syn keyword     cabalConditional    if else elif
+syn match       cabalOperator       "&&\|||\|!"
 syn keyword     cabalFunction       os arch impl flag
-syn match       cabalComment    /--.*$/
-syn match       cabalVersion    "\d\+\(\.\(\d\)\+\)\+\(\.\*\)\?"
+syn match       cabalComment        /--.*$/
+syn match       cabalVersion        "\(==\|>=\|<=\|<\|>\|\^>=\)\s*\d\+\(\.\(\d\)\+\)*\(\.\*\)\?"
 
 syn match       cabalTruth      "\c\<true\>"
 syn match       cabalTruth      "\c\<false\>"
 
 syn match       cabalCompiler   "\c\<ghc\>"
+syn match       cabalCompiler   "\c\<ghcjs\>"
 syn match       cabalCompiler   "\c\<nhc\>"
 syn match       cabalCompiler   "\c\<yhc\>"
 syn match       cabalCompiler   "\c\<hugs\>"
@@ -53,10 +54,20 @@ syn match       cabalCompiler   "\c\<helium\>"
 syn match       cabalCompiler   "\c\<jhc\>"
 syn match       cabalCompiler   "\c\<lhc\>"
 
+syn keyword cabalOs linux osx windows
+
+" version and cabal-version are special, we match the number in them
+syn match	cabalStatement	/^\c\s*\<cabal-version\s*:\s*\(>=\s*\)\?\d\+\(\.\d\+\)/
+syn match	cabalStatement	/^\c\s*\<version\s*:\s*\d\+\(\.\d\+\)*/
+
 syn match	cabalStatement	/^\c\s*\<default-language\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<default-extensions\s*:/me=e-1
 
+syn match	cabalStatement	/^\c\s*\<asm-options\s*:/me=e-1
+syn match	cabalStatement	/^\c\s*\<asm-sources\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<author\s*:/me=e-1
+syn match	cabalStatement	/^\c\s*\<autogen-includes\s*:/me=e-1
+syn match	cabalStatement	/^\c\s*\<autogen-modules\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<branch\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<bug-reports\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<build-depends\s*:/me=e-1
@@ -65,22 +76,25 @@ syn match	cabalStatement	/^\c\s*\<build-tools\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<build-type\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<buildable\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<c-sources\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<cabal-version\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<category\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<cc-options\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<copyright\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<cpp-options\s*:/me=e-1
+syn match	cabalStatement	/^\c\s*\<cxx-options\s*:/me=e-1
+syn match	cabalStatement	/^\c\s*\<cxx-sources\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<data-dir\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<data-files\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<default\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<description\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<executable\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<exposed-modules\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<exposed\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<extensions\s*:/me=e-1
+syn match	cabalStatement	/^\c\s*\<extra-bundled-libraries\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<extra-doc-files\s*:/me=e-1
+syn match	cabalStatement	/^\c\s*\<extra-dynamic-library-flavours\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<extra-lib-dirs\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<extra-libraries\s*:/me=e-1
+syn match	cabalStatement	/^\c\s*\<extra-library-flavours\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<extra-source-files\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<extra-tmp-files\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<for example\s*:/me=e-1
@@ -101,6 +115,7 @@ syn match	cabalStatement	/^\c\s*\<location\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<main-is\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<maintainer\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<manual\s*:/me=e-1
+syn match	cabalStatement	/^\c\s*\<mixins\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<module\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<name\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<nhc98-options\s*:/me=e-1
@@ -115,9 +130,9 @@ syn match	cabalStatement	/^\c\s*\<synopsis\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<tag\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<tested-with\s*:/me=e-1
 syn match	cabalStatement	/^\c\s*\<type\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<version\s*:/me=e-1
 
 syn match	cabalXStatement	/^\c\s*\<x-[a-z_\-]\+\s*:/me=e-1
+
 
 " Define the default highlighting.
 " For version 5.7 and earlier: only when not done already
@@ -140,6 +155,7 @@ if version >= 508 || !exists("did_cabal_syn_inits")
   HiLink cabalConditional   Conditional
   HiLink cabalOperator      Operator
   HiLink cabalCompiler      Constant
+  HiLink cabalOs            Constant
   delcommand HiLink
 endif
 


### PR DESCRIPTION
- Add recently added fields
- Add ghcjs compiler
- Add cabalOs: linux osx windows
- Change cabalVersion to match primitive version ranges
- Change version and cabal-version to match the value too.